### PR TITLE
Add @materialize macro

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -154,3 +154,16 @@ local variables are available in a function using `@unpack_*`.  Examples:
   times.
 
 Thus, in general, it is probably better to use the `@(un)pack` macros instead.
+
+# Materialize macro
+
+The materialize macro is simply an `unpack` macro for Dictionaries. You can use it on `Dict{Symbol,Any}`. It's best shown by example:
+
+```julia 
+d = Dict{Symbol,Any}(:a=>5.0,:b=>2,:c=>"Hi!")
+@materialize a, b, c = d
+a == 5.0 #true
+b == 2 #true
+c == "Hi!" #true
+```
+

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -470,7 +470,7 @@ Splats keys from a dict into variables
 Example:
 
 d = Dict{Symbol,Any}(:a=>5.0,:b=>2,:c=>"Hi!")
-DifferentialEquations.@materialize a, b, c = d
+@materialize a, b, c = d
 a == 5.0 #true
 b == 2 #true
 c == "Hi!" #true

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -12,7 +12,7 @@ import Base: @__doc__
 import DataStructures: OrderedDict
 using Compat
 
-export @with_kw, type2dict, reconstruct, @unpack, @pack
+export @with_kw, type2dict, reconstruct, @unpack, @pack, @materialize
 
 ## Parser helpers
 #################
@@ -458,6 +458,27 @@ macro pack(arg)
         end
         end
     )
+end
+
+"""
+Splats keys from a dict into variables
+
+```
+@materialize a, b, c = dict
+```
+
+"""
+macro materialize(dict_splat)
+    keynames, dict = dict_splat.args
+    keynames = isa(keynames, Symbol) ? [keynames] : keynames.args
+    dict_instance = gensym()
+    kd = [:($key = $dict_instance[$(Expr(:quote, key))]) for key in keynames]
+    kdblock = Expr(:block, kd...)
+    expr = quote
+        $dict_instance = $dict # handle if dict is not a variable but an expression
+        $kdblock
+    end
+    esc(expr)
 end
 
 end # module

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -469,8 +469,8 @@ Splats keys from a dict into variables
 
 Example:
 
-d = Dict{Symbol,Any}(:a=5.0,:b=2,:c="Hi!")
-@materialize a, b, c = d
+d = Dict{Symbol,Any}(:a=>5.0,:b=>2,:c=>"Hi!")
+DifferentialEquations.@materialize a, b, c = d
 a == 5.0 #true
 b == 2 #true
 c == "Hi!" #true

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -463,10 +463,17 @@ end
 """
 Splats keys from a dict into variables
 
-```
+```julia
 @materialize a, b, c = dict
 ```
 
+Example:
+
+d = Dict{Symbol,Any}(:a=5.0,:b=2,:c="Hi!")
+@materialize a, b, c = d
+a == 5.0 #true
+b == 2 #true
+c == "Hi!" #true
 """
 macro materialize(dict_splat)
     keynames, dict = dict_splat.args

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -329,3 +329,11 @@ a = 99
 end
 @test_throws ErrorException T9867()
 @test T9867(r=2).r == 2
+
+# Materialize tests
+
+d = Dict{Symbol,Any}(:a=>5.0,:b=>2,:c=>"Hi!")
+@materialize a, b, c = d
+@test a == 5.0
+@test b == 2
+@test c == "Hi!"


### PR DESCRIPTION
The materialize macro is a utility function from GLVisualize which seems well-suited for this package. It splats a dictionary to variables in a similar way to how your `@unpack` splats a type to variables.