### PR TITLE
return the structure back in @pack

### DIFF
--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -539,6 +539,7 @@ macro pack(args)
     expr = quote
         $suitecase_instance = $suitecase # handle if suitecase is not a variable but an expression
         $kdblock
+        $suitecase
     end
     esc(expr)
 end


### PR DESCRIPTION
It is often convenient to have @pack as a last statement in a function and return the structure back at the same time:

```
function work(state)
  @unpack a, b = state
  a += b
  @pack state = a
end

new_state = work(state)
```