### PR TITLE
named tuple support

### DIFF
--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -44,7 +44,7 @@ module Parameters
 import Base: @__doc__
 import DataStructures: OrderedDict
 using Compat
-
+include("kw_params.jl")
 export @with_kw, @with_kw_noshow, type2dict, reconstruct, @unpack, @pack
 
 ## Parser helpers
@@ -740,4 +740,5 @@ end
 # TODO: maybe add @pack_new for packing into a new instance.  Could be
 # used with immutables also.
 
+#### Named Tuple constructor
 end # module

--- a/src/kw_params.jl
+++ b/src/kw_params.jl
@@ -1,0 +1,36 @@
+using Match, NamedTuples
+"""
+Macro which takes assignment arguments (e.g., "a=2") and gives us a Named Tuple constructor that
+(a) has those assignments as defaults, and (b) takes keyword redefinitions. 
+
+This depends on NamedTuples.jl and Match.jl for v0.6.
+"""
+macro kw_params(args...)
+    # Clean and parse input. 
+    splits = map(args) do arg
+        @match arg begin
+            Expr(:(=), args, _) => (args[1], args[2])
+            Expr(:tuple, args, _) => error("Extra space between macro and argument.")
+            any_ => error("All arguments must be assignments")
+        end
+    end
+    
+    # Interpolation step. 
+    assignments = []
+    function clean(splits)
+        for split in splits
+            push!(assignments, (split[1], eval(split[2])))
+        end 
+    end
+    
+    # Package and return function. 
+    clean(splits)
+    esc(:(
+    (;$(map(assignments) do pair 
+    Expr(:kw, pair[1], pair[2])
+    end...),) -> 
+    $NamedTuples.@NT($(map(assignments) do pair 
+        Expr(:kw, pair[1], pair[1])
+    end...))
+    ))
+end


### PR DESCRIPTION
This is probably clumsily done, but I think this resolves the Named Tuple factory issue that @jlperla had posted. I think the main caveat, in terms of functionality, is that, if you're passing in a symbol `@kw_params(x = :x)`, you need to escape it one level `@kw_params(x = :(:x))`.

