### PR TITLE
Drop Julia-0.6 and add NamedTuples (fix 55)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
-# matrix:
-#   allow_failures:
-#     - julia: nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
 # https://github.com/travis-ci/travis-ci/issues/4942

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.6
   - 0.7
   - nightly
 matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
-DataStructures 0.7.2
+julia 0.7
+DataStructures
 Compat

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.7
-DataStructures
+julia 0.6
+DataStructures 0.8
 Compat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.7-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.7-latest-win64.exe"
+  # - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  # - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 environment:
   matrix:
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
   # - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.7-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.7-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
   # - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   # - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -296,7 +296,10 @@ function with_kw(typedef, mod::Module, withshow=true)
         withshow==false && error("`@with_kw_noshow` not supported for named tuples")
         return with_kw_nt(typedef, mod)
     elseif typedef.head != :struct
-        error("only works on type-defs or named tuples.  (Make sure to have a space after @with_kw`.)")
+        error("""Only works on type-defs or named tuples.
+              Make sure to have a space after `@with_kw`, e.g. `@with_kw (a=1,)
+              Also, make sure to use a trailing comma for single-field NamedTuples.
+              """)
     end
     err1str = "Field \'"
     err2str = "\' has no default, supply it with keyword."
@@ -408,7 +411,7 @@ function with_kw(typedef, mod::Module, withshow=true)
                 docstring = string("Default: ", l.args[2])
                 if i > 1 && lns[i-1] isa String
                     # if the last line was a docstring, append the default
-                    fielddefs.args[end] *= " " * docstring 
+                    fielddefs.args[end] *= " " * docstring
                 else
                     # otherwise add a new line
                     push!(fielddefs.args, docstring)
@@ -586,11 +589,11 @@ function with_kw_nt(typedef, mod)
         end
     end
     nt = Expr(:tuple, nt...)
-    f = gensym(:NT_kwconstructor)
+    NT = gensym(:NamedTuple_kw)
     quote
-        $f = (; $(kwargs...)) -> $nt
-        (::typeof($f))($(args...)) = $nt
-        $f
+        $NT = (; $(kwargs...)) -> $nt
+        (::typeof($NT))($(args...)) = $nt
+        $NT
     end
 end
 
@@ -614,6 +617,13 @@ macro with_kw(typedef)
     else
         return esc(with_kw(typedef, current_module(), true))
     end
+end
+
+macro with_kw(args...)
+    error("""Only works on type-defs or named tuples.
+          Did you try to construct a NamedTuple but omitted the space between the macro and the NamedTuple?
+          Do `@with_kw (a=1, b=2)` and not `@with_kw(a=1, b=2)`.
+          """)
 end
 
 """

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 Compat 0.26.0
+NamedTuples

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -410,6 +410,12 @@ MyNT = @with_kw (a=1, b="test", w=:uu)
 MyNT2 = @with_kw (a=1, b="test", w)
 @test_throws ErrorException MyNT2() # no default for w
 
+MyNT3 = @with_kw (a=1, b=a)
+@test MyNT3()==(a=1, b=1)
+@test MyNT3(a=2)==(a=2, b=2)
+@test MyNT3(b=2)==(a=1, b=2)
+
+
 ###########################
 # Packing and unpacking @unpack, @pack
 ##########################

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -463,48 +463,39 @@ d = A(4,7.0,"Hi")
 
 # older tests ported
 mutable struct UP1
-    a
-    b
+    aUP1
+    bUP1
 end
 uu = UP1(1,2)
-@test_throws ErrorException @unpack c = uu
-@test_throws ErrorException @unpack a, c = uu
+@test_throws ErrorException @unpack cUP1 = uu
+@test_throws ErrorException @unpack aUP1, cUP1 = uu
 
-a, b = 0, 0
-@unpack a = uu
-@test a==1
-@test b==0
-a, b = 0, 0
-@unpack a, b = uu
-@test a==1
-@test b==2
+aUP1, bUP1 = 0, 0
+@unpack aUP1 = uu
+@test aUP1==1
+@test bUP1==0
+aUP1, bUP1 = 0, 0
+@unpack aUP1, bUP1 = uu
+@test aUP1==1
+@test bUP1==2
 
 
 vv = uu
-a = 99
-@pack uu = a
+aUP1 = 99
+@pack uu = aUP1
 @test uu==vv
-@test uu.a==99
+@test uu.aUP1==99
 
 struct UP2
-    a
-    b
+    aUP2
+    bUP2
 end
 uu = UP2(1,2)
-@test_throws ErrorException @unpack c = uu
-@test_throws ErrorException @unpack a, c = uu
+@test_throws ErrorException @unpack cUP2 = uu
+@test_throws ErrorException @unpack aUP2, cUP2 = uu
 
-a, b = 0, 0
-@unpack a = uu
-@test a==1
-@test b==0
-a, b = 0, 0
-@unpack a,b = uu
-@test a==1
-@test b==2
-
-a = 99
-@test_throws ErrorException @pack uu = a
+aUP1 = 99
+@test_throws ErrorException @pack uu = aUP1
 
 # check that inference works
 struct UP3


### PR DESCRIPTION
Fixes #55.  This implements NamedTuples with default values as suggested by @jlperla on [Discourse](https://discourse.julialang.org/t/macro-challenge-factory-for-creating-named-tuples/9748):
```julia
MyNT = @with_kw (a=1, b="test", w=:uu)
MyNT()==(a=1, b="test", w=:uu)
```
This is an alternate implementation of @ArnavSood's PR #62, which I started working on before that PR and was actually close to finished.  So I finished it here, sorry.

This also drops Julia 0.7, for which I don't really want to add new features at this stage.  If someone feels strongly about this, they are welcome to take this PR and re-add Julia 0.6 to it.