### PR TITLE
Tests and Docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 2018-07-10
+
+Added named tuple support. 
+
 # 2017-09-26
 
 Dropped Julia 0.5 support.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@
 [![Parameters](http://pkg.julialang.org/badges/Parameters_0.7.svg)](http://pkg.julialang.org/detail/Parameters)
 
 This is a package I use to handle numerical-model parameters, thus the
-name.  However, it should be useful otherwise too.  It has two main
+name.  However, it should be useful otherwise too.  It has three main
 features:
 
-- keyword type constructors with default values, and
+- keyword type constructors with default values,
+- named tuple constructors with default values, and 
 - unpacking and packing of composite types and dicts.
 
 The macro `@with_kw` which decorates a type definition to
@@ -42,6 +43,33 @@ A
   b: -1.1
   c: 4
 ```
+
+The macro also supports constructors for named tuples with default values; e.g.
+
+```julia
+julia> MyNT = @with_kw (x = 1, y = "foo", z = :(bar))
+(::#5) (generic function with 2 methods)
+
+julia> MyNT()
+(x = 1, y = "foo", z = :bar)
+```
+
+These constructors can be used as bona fide constructors; e.g. 
+
+```julia
+julia> MyNT(x = 2)
+(x = 2, y = "foo", z = :bar)
+
+julia> MyNT(z = x -> x^3)
+(x = 1, y = "foo", z = #8)
+```
+
+These named tuples can be unpacked exactly like other decorated `struct`s (see below). 
+
+> NOTE: The main caveat is not to reuse a symbol across different assignments; i.e. `MyNT = @with_kw (x = y, c = x)` will yield 
+`MyNT() = (x = foo, c = foo)`, where `foo` is the initial value of `y`. In v0.6, assignments of the kind `f = f` are not supported. 
+
+In v0.6, `NamedTuples.jl` is a prerequisite for named tuple support. In v0.7, they are included in base Julia. 
 
 Unpacking is done with `@unpack` (`@pack` is similar):
 ```julia

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ julia> MyNT(z = x -> x^3)
 (x = 1, y = "foo", z = #8)
 ```
 
-These named tuples can be unpacked exactly like other decorated `struct`s (see below). 
+These named tuples can be unpacked using `@unpack` (see below). 
 
 > NOTE: The main caveat is not to reuse a symbol across different assignments; i.e. `MyNT = @with_kw (x = y, c = x)` will yield 
 `MyNT() = (x = foo, c = foo)`, where `foo` is the initial value of `y`. In v0.6, assignments of the kind `f = f` are not supported. 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@
 [![Parameters](http://pkg.julialang.org/badges/Parameters_0.7.svg)](http://pkg.julialang.org/detail/Parameters)
 
 This is a package I use to handle numerical-model parameters, thus the
-name.  However, it should be useful otherwise too.  It has three main
+name.  However, it should be useful otherwise too.  It has two main
 features:
 
-- keyword type constructors with default values,
-- named tuple constructors with default values, and 
+- keyword type constructors with default values for `struct`s and `NamedTuples`,
 - unpacking and packing of composite types and dicts.
 
 The macro `@with_kw` which decorates a type definition to
@@ -52,24 +51,12 @@ julia> MyNT = @with_kw (x = 1, y = "foo", z = :(bar))
 
 julia> MyNT()
 (x = 1, y = "foo", z = :bar)
-```
 
-These constructors can be used as bona fide constructors; e.g. 
-
-```julia
 julia> MyNT(x = 2)
 (x = 2, y = "foo", z = :bar)
-
-julia> MyNT(z = x -> x^3)
-(x = 1, y = "foo", z = #8)
 ```
 
-These named tuples can be unpacked using `@unpack` (see below). 
-
-> NOTE: The main caveat is not to reuse a symbol across different assignments; i.e. `MyNT = @with_kw (x = y, c = x)` will yield 
-`MyNT() = (x = foo, c = foo)`, where `foo` is the initial value of `y`. In v0.6, assignments of the kind `f = f` are not supported. 
-
-In v0.6, `NamedTuples.jl` is a prerequisite for named tuple support, and needs to be loaded via `import` or `using`. In v0.7, they are included in base Julia. 
+> v0.6 users: since `NamedTuples` are not supported in base Julia v0.6, you must import the `NamedTuples.jl` package. Be aware of [this issue](https://github.com/JuliaLang/julia/issues/17240) with keyword arguments in v0.6. 
 
 Unpacking is done with `@unpack` (`@pack` is similar):
 ```julia

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ These named tuples can be unpacked exactly like other decorated `struct`s (see b
 > NOTE: The main caveat is not to reuse a symbol across different assignments; i.e. `MyNT = @with_kw (x = y, c = x)` will yield 
 `MyNT() = (x = foo, c = foo)`, where `foo` is the initial value of `y`. In v0.6, assignments of the kind `f = f` are not supported. 
 
-In v0.6, `NamedTuples.jl` is a prerequisite for named tuple support. In v0.7, they are included in base Julia. 
+In v0.6, `NamedTuples.jl` is a prerequisite for named tuple support, and needs to be loaded via `import` or `using`. In v0.7, they are included in base Julia. 
 
 Unpacking is done with `@unpack` (`@pack` is similar):
 ```julia

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -129,6 +129,52 @@ PhysicalPara{Float64}
 If this `show` method definition is not desired, for instance because of method
 re-definition warnings, then use [`@with_kw_noshow`](@ref).
 
+## Named Tuple Support 
+
+As mentioned in the README, the `@with_kw` macro can be used to decorate a named tuple and produce a named tuple constructor with those defaults. 
+
+> Users of Julia v0.6 should be aware of this [caveat](https://github.com/JuliaLang/julia/issues/17240) that prohibits assignments like `@with_kw (f = f, x = x)`. This is a consequence of different scoping rules for keyword arguments in [v0.6](https://docs.julialang.org/en/stable/manual/functions/#Evaluation-Scope-of-Default-Values-1) and [v0.7](https://docs.julialang.org/en/latest/manual/functions/#Evaluation-Scope-of-Default-Values-1). 
+
+> Users of v0.6 will also need to explicitly import `NamedTuples.jl`, since this functionality is not present in that version of base Julia. 
+
+These named tuples can be defined as such: 
+
+```julia
+MyNT = @with_kw (f = x -> x^3, y = 3, z = "foo")
+```
+
+And the constructors can be used as follows:
+
+```julia
+julia> MyNT(f = x -> x^2, z = :foo)
+(f = #12, y = 3, z = :foo)
+```
+
+The constructor is not type-locked:
+
+```julia
+julia> MyNT(f = "x -> x^3")
+(f = "x -> x^3", y = 3, z = "foo")
+```
+
+And these named tuples can unpacked in the usual way (see below).
+
+```julia
+julia> @unpack f, y, z = MyNT()
+(f = #7, y = 3, z = "foo")
+
+julia> f
+(::#7) (generic function with 1 method)
+
+julia> y
+3
+
+julia> z
+"foo"
+```
+
+Since the macro operates on a single tuple expression (as opposed to a tuple of assignment expressions),writing `@with_kw(x = 1, y = :foo)` will return an error suggesting you write `@with_kw (x = 1, y = :foo)`.
+
 # (Un)pack macros
 
 When working with parameters, or otherwise, it is often convenient to

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -500,7 +500,7 @@ else
         scopingTest = @with_kw (f = f,)
         @test_broken scopingTest().f(2) == 8 # Something wrong with doing this directly. 
         x = [1, 2, 3]
-        scopingTest = @with_kw (x = x)
+        scopingTest = @with_kw (x = x,)
         @test scopingTest().x == [1, 2, 3]
         @test_throws ErrorException eval(:(@with_kw (a = 1, a = 2,))) # Duplicate values handling 
         obj = MyNT()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -509,7 +509,7 @@ else
         immutabilityTest = @with_kw (f = x,)
         obj = immutabilityTest()
         x = [4, 5, 6]
-        @test obj.f == [4, 5, 6] # Test MUTABILITY per the rules of v0.7
+        @test obj.f == [1, 2, 3] # Test immutability per the rules of v0.7
         undefTest = @with_kw (x = ζ + 2,)
         @test_throws UndefVarError undefTest() # Check use of undefined variables. 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -498,8 +498,6 @@ else
         x = [1, 2, 3]
         scopingTest = @with_kw (x = x,)
         @test scopingTest().x == [1, 2, 3]
-        obj = MyNT()
-        @test_throws ErrorException obj.a = 2 # Immutability against object setting
         x = [1, 2, 3]
         immutabilityTest = @with_kw (f = x,)
         obj = immutabilityTest()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -498,7 +498,7 @@ else
         @test_throws ErrorException MyNT().z # Undefined field access
         f(x) = x -> x^3
         scopingTest = @with_kw (f = f,)
-        func = scopingTest.f
+        func = scopingTest().f
         @test func(2) == 8 # Scoping
         @test_broken scopingTest().f(2) == 8 # Something wrong with doing this directly. 
         @test_throws ErrorException eval(:(@with_kw (a = 1, a = 2,))) # Duplicate values handling 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -498,7 +498,9 @@ else
         @test_throws ErrorException MyNT().z # Undefined field access
         f(x) = x -> x^3
         scopingTest = @with_kw (f = f,)
-        @test scopingTest().f(2) == 8 # Scoping failure.
+        func = scopingTest.f
+        @test func(2) == 8 # Scoping
+        @test_broken scopingTest().f(2) == 8 # Something wrong with doing this directly. 
         @test_throws ErrorException eval(:(@with_kw (a = 1, a = 2,))) # Duplicate values handling 
         obj = MyNT()
         @test_throws ErrorException obj.a = 2 # Immutability against object setting

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -498,9 +498,10 @@ else
         @test_throws ErrorException MyNT().z # Undefined field access
         f(x) = x -> x^3
         scopingTest = @with_kw (f = f,)
-        func = scopingTest().f
-        @test func(2) == 8 # Scoping
         @test_broken scopingTest().f(2) == 8 # Something wrong with doing this directly. 
+        x = [1, 2, 3]
+        scopingTest = @with_kw (x = x)
+        @test scopingTest().x == [1, 2, 3]
         @test_throws ErrorException eval(:(@with_kw (a = 1, a = 2,))) # Duplicate values handling 
         obj = MyNT()
         @test_throws ErrorException obj.a = 2 # Immutability against object setting

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -448,7 +448,7 @@ if VERSION<v"0.7-"
 
         @test_throws ErrorException MyNT().z # Undefined field access
         q = x -> x^3
-        scopingTest = @with_kw (q = q)
+        scopingTest = @with_kw (q = q,)
         @test_broken scopingTest() # Scoping failure.
         @test_throws ErrorException eval(:(@with_kw (a = 1, a = 2,))) # Duplicate values handling 
         obj = MyNT()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -447,8 +447,8 @@ if VERSION<v"0.7-"
         @test MyNT3(b=2)==@NT(a=1, b=2)
 
         @test_throws ErrorException MyNT().z # Undefined field access
-        f(x) = x -> x^3
-        scopingTest = @with_kw (f = f,)
+        q = x -> x^3
+        scopingTest = @with_kw (q = q)
         @test_broken scopingTest() # Scoping failure.
         @test_throws ErrorException eval(:(@with_kw (a = 1, a = 2,))) # Duplicate values handling 
         obj = MyNT()
@@ -496,9 +496,9 @@ else
         @test MyNT3(b=2)==(a=1, b=2)
 
         @test_throws ErrorException MyNT().z # Undefined field access
-        f(x) = x -> x^3
-        scopingTest = @with_kw (f = f,)
-        @test_broken scopingTest().f(2) == 8 # Something wrong with doing this directly. 
+        q = x -> x^3
+        scopingTest = @with_kw (q = q,)
+        @test scopingTest().q(2) == 8 # Something wrong with doing this directly. 
         x = [1, 2, 3]
         scopingTest = @with_kw (x = x,)
         @test scopingTest().x == [1, 2, 3]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -448,18 +448,14 @@ if VERSION<v"0.7-"
 
         @test_throws ErrorException MyNT().z # Undefined field access
         q = x -> x^3
-        scopingTest = @with_kw (q = q,)
-        @test_broken scopingTest() # Scoping failure.
-        @test_throws ErrorException eval(:(@with_kw (a = 1, a = 2,))) # Duplicate values handling 
-        obj = MyNT()
-        @test_throws ErrorException obj.a = 2 # Immutability 
+        scopingTest = @with_kw (q = q,) # See https://github.com/JuliaLang/julia/issues/17240
+        @test_throws UndefVarError scopingTest()
         x = [1, 2, 3]
         immutabilityTest = @with_kw (f = x,)
         obj = immutabilityTest()
         x = [4, 5, 6]
-        @test obj.f == [1, 2, 3] # Test immutability per the rules of v0.6
-        undefTest = @with_kw (x = ζ + 2,)
-        @test_throws UndefVarError undefTest() # Check use of undefined variables. 
+        @test obj.f == [1, 2, 3] # Test immutability for old object 
+        @test immutabilityTest().f == [4, 5, 6] # Test rebinding for new object 
         
         # Exotic input test 
         naughtyInputs = ["!@#\$%^&*()`~", :"()esc(;", :x, :(eval(:x)), true, esc(true), "-9223372036854775808/-1", :(0/0), "-9223372036854775808/-1", "0xabad1dea", :(@test)]
@@ -498,20 +494,18 @@ else
         @test_throws ErrorException MyNT().z # Undefined field access
         q = x -> x^3
         scopingTest = @with_kw (q = q,)
-        @test scopingTest().q(2) == 8 # Something wrong with doing this directly. 
+        @test scopingTest().q(2) == 8 
         x = [1, 2, 3]
         scopingTest = @with_kw (x = x,)
         @test scopingTest().x == [1, 2, 3]
-        @test_throws ErrorException eval(:(@with_kw (a = 1, a = 2,))) # Duplicate values handling 
         obj = MyNT()
         @test_throws ErrorException obj.a = 2 # Immutability against object setting
         x = [1, 2, 3]
         immutabilityTest = @with_kw (f = x,)
         obj = immutabilityTest()
         x = [4, 5, 6]
-        @test obj.f == [1, 2, 3] # Test immutability per the rules of v0.7
-        undefTest = @with_kw (x = ζ + 2,)
-        @test_throws UndefVarError undefTest() # Check use of undefined variables. 
+        @test obj.f == [1, 2, 3] # Test immutability 
+        @test immutabilityTest().f == [4, 5, 6] # Test rebinding for new object 
 
          # Exotic input test 
          naughtyInputs = ["!@#\$%^&*()`~", :"()esc(;", :x, :(eval(:x)), true, esc(true), "-9223372036854775808/-1", :(0/0), "-9223372036854775808/-1", "0xabad1dea", :(@test)]


### PR DESCRIPTION
What it says on the tin. @mauro3, two things to note- 

1. This is currently necessary in v0.6:

```
        f = x -> x^3
        scopingTest = @with_kw (f = f,)
        @test_broken scopingTest() # Scoping failure.
```

In other words, I think v0.6 displays the general scoping issue with `f = f`.

2. `[There was an issue here, but I realized the problem was on my end.]`