### PR TITLE
Take out the deepcopy calls

### DIFF
--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -104,7 +104,7 @@ decolon2(a::Symbol) = a
 # Keep the ::T of the args if T ∈ typparas,
 # leave symbols as is, drop field-doc-strings.
 function keep_only_typparas(args, typparas)
-    args = deepcopy(args)
+    args = copy(args)
     tokeep = Int[]
     typparas_ = map(stripsubtypes, typparas)
     for i=1:length(args)
@@ -445,7 +445,7 @@ function with_kw(typedef, mod::Module, withshow=true)
         end
     end
     # The type definition without inner constructors:
-    typ = Expr(:struct, deepcopy(typedef.args[1:2])..., deepcopy(fielddefs))
+    typ = Expr(:struct, typedef.args[1:2]..., copy(fielddefs))
 
     # Inner keyword constructor.  Note that this calls the positional
     # constructor under the hood and not `new`.  That way a user can

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -393,6 +393,11 @@ end
 @test_throws ErrorException T9867()
 @test T9867(r=2).r == 2
 
+# issue #56: spliced-in modules
+@eval @with_kw struct SplicedModule <: $Base.AbstractVector{Int}
+    x
+end
+@test SplicedModule(12).x == 12
 
 # NamedTuples
 ###


### PR DESCRIPTION
Fix #56 

I reviewed the logic carefully to make sure that the replacements were all acceptable. Fun fact I learned: `copy(::Expr)` is already [recursive](https://github.com/JuliaLang/julia/blob/master/base/expr.jl#L35-L39), which is why `copy(fielddefs)` is an acceptable replacement.