### PR TITLE
Use property interface

### DIFF
--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -229,7 +229,7 @@ Two definitions are included in the package to unpack a composite type/module
 or a dictionary with Symbol or string keys:
 
 ```
-@inline unpack{f}(x, ::Val{f}) = getfield(x, f)
+@inline unpack{f}(x, ::Val{f}) = getproperty(x, f)
 @inline unpack{k}(x::Associative{Symbol}, ::Val{k}) = x[k]
 @inline unpack{S<:AbstractString,k}(x::Associative{S}, ::Val{k}) = x[string(k)]
 ```
@@ -243,7 +243,7 @@ Two definitions are included in the package to pack into a composite
 type or into a dictionary with Symbol or string keys:
 
 ```
-@inline pack!{f}(x, ::Val{f}, val) = setfield!(x, f, val)
+@inline pack!{f}(x, ::Val{f}, val) = setproperty!(x, f, val)
 @inline pack!{k}(x::Associative{Symbol}, ::Val{k}, val) = x[k]=val
 @inline pack!{S<:AbstractString,k}(x::Associative{S}, ::Val{k}, val) = x[string(k)]=val
 ```

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -188,8 +188,8 @@ Dict{Symbol,Any} with 2 entries:
 """
 function type2dict(dt)
     di = Dict{Symbol,Any}()
-    for n in fieldnames(typeof(dt))
-        di[n] = getfield(dt, n)
+    for n in propertynames(dt)
+        di[n] = getproperty(dt, n)
     end
     di
 end

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -662,7 +662,7 @@ The `field` is the symbol of the assigned variable.
 Three definitions are included in the package to unpack a composite type
 or a dictionary with Symbol or string keys:
 ```
-@inline unpack(x, ::Val{f}) where {f} = getfield(x, f)
+@inline unpack(x, ::Val{f}) where {f} = getproperty(x, f)
 @inline unpack(x::AbstractDict{Symbol}, ::Val{k}) where {k} = x[k]
 @inline unpack(x::AbstractDict{S}, ::Val{k}) where {S<:AbstractString,k} = x[string(k)]
 ```
@@ -672,7 +672,7 @@ More methods can be added to allow for specialized unpacking of other datatypes.
 See also `pack!`.
 """
 function unpack end
-@inline unpack(x, ::Val{f}) where {f} = getfield(x, f)
+@inline unpack(x, ::Val{f}) where {f} = getproperty(x, f)
 @inline unpack(x::AbstractDict{Symbol}, ::Val{k}) where {k} = x[k]
 @inline unpack(x::AbstractDict{<:AbstractString}, ::Val{k}) where {k} = x[string(k)]
 
@@ -689,7 +689,7 @@ Two definitions are included in the package to pack into a composite
 type or into a dictionary with Symbol or string keys:
 
 ```
-@inline pack!(x, ::Val{f}, val) where {f} = setfield!(x, f, val)
+@inline pack!(x, ::Val{f}, val) where {f} = setproperty!(x, f, val)
 @inline pack!(x::AbstractDict{Symbol}, ::Val{k}, val) where {k} = x[k]=val
 @inline pack!(x::AbstractDict{S}, ::Val{k}, val) where {S<:AbstractString,k} = x[string(k)]=val
 ```
@@ -700,7 +700,7 @@ datatypes.
 See also `unpack`.
 """
 function pack! end
-@inline pack!(x, ::Val{f}, val) where {f} = setfield!(x, f, val)
+@inline pack!(x, ::Val{f}, val) where {f} = setproperty!(x, f, val)
 @inline pack!(x::AbstractDict{Symbol}, ::Val{k}, val) where {k} = x[k]=val
 @inline pack!(x::AbstractDict{<:AbstractString}, ::Val{k}, val) where {k} = x[string(k)]=val
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -463,6 +463,24 @@ d = Dict("a"=>5.0,"b"=>2,"c"=>"Hi!")
 @test a == 5.0 #true
 @test c == "Hi!" #true
 
+mutable struct PropertyExample
+    a
+    last_set_property
+end
+Base.getproperty(::PropertyExample, name::Symbol) = String(name)
+Base.setproperty!(d::PropertyExample, name::Symbol, value) =
+    setfield!(d, :last_set_property, (name, value))
+
+let d = PropertyExample(:should_be_ignored, nothing)
+    @unpack a, b = d
+    @test a == "a"
+    @test b == "b"
+
+    a = "a value"
+    @pack! d = a
+    @test getfield(d, :last_set_property) == (:a, "a value")
+end
+
 # TODO add test with non String string
 
 # Example with type:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -470,6 +470,7 @@ end
 Base.getproperty(::PropertyExample, name::Symbol) = String(name)
 Base.setproperty!(d::PropertyExample, name::Symbol, value) =
     setfield!(d, :last_set_property, (name, value))
+Base.propertynames(::PropertyExample) = (:A, :B, :C)
 
 let d = PropertyExample(:should_be_ignored, nothing)
     @unpack a, b = d
@@ -479,6 +480,8 @@ let d = PropertyExample(:should_be_ignored, nothing)
     a = "a value"
     @pack! d = a
     @test getfield(d, :last_set_property) == (:a, "a value")
+
+    @test type2dict(d) == Dict(:A => "A", :B => "B", :C => "C")
 end
 
 # TODO add test with non String string


### PR DESCRIPTION
fixes #49

A part I didn't touch is:

https://github.com/mauro3/Parameters.jl/blob/870131fa4114af141b4c40d8275259e5d19e444b/src/Parameters.jl#L229-L233

in `reconstruct`.  I think it's better as-is.  What do you think?
