### PR TITLE
Implement at-pack_* for immutable

### DIFF
--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -256,7 +256,7 @@ function _pack_mutable(binding, fields)
     push!(e.args, binding)
     e
 end
-function _pack_immutable(T, fields)
+function _pack_new(T, fields)
     Expr(:call, T, fields...)
 end
 
@@ -553,15 +553,14 @@ function with_kw(typedef, mod::Module, withshow=true)
             macro $pack!_name(ex)
                 esc($Parameters._pack_mutable(ex, $unpack_vars))
             end
-            macro $pack_name(ex)
-                Base.depwarn("The macro `@$($(Meta.quot(pack_name)))` is deprecated, use `@$($(Meta.quot(pack!_name)))`", $(QuoteNode(pack_name)) )
-                esc($Parameters._pack_mutable(ex, $unpack_vars))
+            macro $pack_name()
+                esc($Parameters._pack_new($tn, $unpack_vars))
             end
         end
     else
         pack_macros = quote
             macro $pack_name()
-                esc($Parameters._pack_immutable($tn, $unpack_vars))
+                esc($Parameters._pack_new($tn, $unpack_vars))
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -329,6 +329,10 @@ let
     else
         @test string(mt) == "P1m\n  r: Int32 1\n  c: Int32 3\n  a: Float64 2.0\n"
     end
+    mt2 = let P1m = error  # `P1m` should not be resolved in this namespace
+        @pack_P1m
+    end
+    @test (mt2.r, mt2.c, mt2.a) == (r, c, a)
 end
 
 ### Assertions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -302,9 +302,8 @@ let
     a = 2
     c = 3
     @test_throws LoadError eval(:(@pack!_P1 mt))
-    local mt2
-    let P1 = error  # `P1` should not be resolved in this namespace
-        @pack_P1! mt2
+    mt2 = let P1 = error  # `P1` should not be resolved in this namespace
+        @pack_P1
     end
     @test mt2 === P1(r=r, c=c, a=a)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -323,16 +323,17 @@ let
     r = 1
     a = 2
     c = 3
+    mt2 = let P1m = error  # `P1m` should not be resolved in this namespace
+        @pack_P1m
+    end
+    @test (mt2.r, mt2.c, mt2.a) == (r, c, a)
+    @test (mt.r, mt.c, mt.a) === (4, 6, 5.0)  # mt is unmodified
     @pack_P1m! mt
     if Int==Int64
         @test string(mt) == "P1m\n  r: Int64 1\n  c: Int64 3\n  a: Float64 2.0\n"
     else
         @test string(mt) == "P1m\n  r: Int32 1\n  c: Int32 3\n  a: Float64 2.0\n"
     end
-    mt2 = let P1m = error  # `P1m` should not be resolved in this namespace
-        @pack_P1m
-    end
-    @test (mt2.r, mt2.c, mt2.a) == (r, c, a)
 end
 
 ### Assertions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -302,6 +302,11 @@ let
     a = 2
     c = 3
     @test_throws LoadError eval(:(@pack!_P1 mt))
+    local mt2
+    let P1 = error  # `P1` should not be resolved in this namespace
+        @pack_P1! mt2
+    end
+    @test mt2 === P1(r=r, c=c, a=a)
 end
 
 @with_kw mutable struct P1m


### PR DESCRIPTION
This PR adds `@pack_$T` macro to construct an object of type `T`:

```julia
julia> @with_kw struct P1
           r::Int
           c
           a::Float64
       end
P1

julia> @unpack_P1 P1(r=4, a=5, c=6)
5.0

julia> @pack_P1
P1
  r: Int64 4
  c: Int64 6
  a: Float64 5.0
```