### PR TITLE
Make use of ConstructionBase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.mem
 docs/build/
 tmp*
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ author = ["Mauro Werder <mauro3@runbox.com>"]
 version = "0.12.0"
 
 [deps]
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -41,12 +41,12 @@ c = BB.c
 module Parameters
 import ConstructionBase
 using ConstructionBase: setproperties
-export setproperties
 
 import Base: @__doc__
 import OrderedCollections: OrderedDict
 
 export @with_kw, @with_kw_noshow, type2dict, reconstruct, @unpack, @pack!, @pack
+export setproperties
 
 ## Parser helpers
 #################

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,8 @@ end
 # @test "A field Default: sdaf\n" == Markdown.plain(@doc MT1.c)
 @test "Field r Default: 4\n" == Markdown.plain(REPL.fielddoc(MT1, :r))
 @test "A field Default: sdaf\n" == Markdown.plain(REPL.fielddoc(MT1, :c))
+@test setproperties(MT1(), r=12).r === 12
+@test setproperties(MT1(), r=12, c=nothing).c === nothing
 
 abstract type AMT1_2 end
 "Test documentation with type-parameter"
@@ -75,7 +77,8 @@ const TMT1_3 = MT1_3{Int} # Julia bug https://github.com/JuliaLang/julia/issues/
 end
 MT2(r=4, a=5., c=6)
 MT2(r=4, a=5, c="asdf")
-MT2(4, "dsaf", 5)
+obj = MT2(4, "dsaf", 5)
+@test setproperties(obj, (r=42, c=:c)).r === 42
 @test_throws ErrorException MT2(r=4)
 @test_throws ErrorException MT2()
 
@@ -114,6 +117,12 @@ MT3_2(a=5)
 MT3_2(4,5)
 @test_throws ErrorException MT3_2(r=4)
 @test_throws ErrorException MT3_2()
+o = MT3_2(r=4, a=5.0)
+o2 = setproperties(o, r=10, a=20)
+@test o2.r === 10
+@test o2.a === 20.0
+@test o.r === 4
+@test o.a === 5.0
 
 # with type-parameters
 @with_kw struct MT4{R,I}
@@ -130,6 +139,8 @@ mt4=MT4(5.4, 4) # outer positional
 @test_throws ErrorException MT4{Float32, Int}()
 @test_throws InexactError MT4{Float32,Int}(a=5.5)
 @test_throws InexactError MT4{Float32,Int}(5.5, 5.5)
+@test setproperties(MT4(a=1), r=12.0).r === 12.0
+@test setproperties(MT4(a=1), r=12, a=:hello).a === :hello
 
 # with type-parameters 2
 abstract type AMT{R<:Real} end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,11 +4,11 @@ using Parameters, Test, Markdown, REPL
 a8679 = @eval (a=1, b=2)
 ra8679 = @eval (a=1, b=44)
 @test ra8679 == reconstruct(a8679, b=44)
-@test_throws ErrorException reconstruct(a8679, c=44)
+@test_throws ArgumentError reconstruct(a8679, c=44)
 
 a8679 = Dict(:a=>1, :b=>2)
 @test Dict(:a=>1, :b=>44) == reconstruct(a8679, b=44)
-@test_throws ErrorException reconstruct(a8679, c=44)
+@test_throws KeyError reconstruct(a8679, c=44)
 
 struct A8679
     a
@@ -16,7 +16,7 @@ struct A8679
 end
 a8679 = A8679(1, 2)
 @test A8679(1, 44) == reconstruct(a8679, b=44)
-@test_throws ErrorException reconstruct(a8679, c=44)
+@test_throws ArgumentError reconstruct(a8679, c=44)
 
 ##########
 # @with_kw


### PR DESCRIPTION
Various packages implement variants of `Parameters.reconstruct`. [ConstructionBase.jl](https://github.com/JuliaObjects/ConstructionBase.jl) is an effort to unify these. Benefits are:
* Better performance: `ConstructionBase.setproperties` is very fast
* More dry
* Better interoperability: For instance if a user wants a type with customized `getproperty` to interact well with both `Setfield.jl` and `Parameters.jl`, she only needs to overload one function.

See also https://github.com/JuliaObjects/ConstructionBase.jl/issues/6
ConstructionBase is not yet released, so CI will fail and this PR should not yet be merged.