### PR TITLE
type2dict change type to struct

### DIFF
--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -176,7 +176,7 @@ end
 Transforms a type-instance into a dictionary.
 
 ```
-julia> type T
+julia> struct T
            a
            b
        end


### PR DESCRIPTION
Noticed in the Parameters.jl API that this hasn't been updated from type T to struct T. Example now works