### PR TITLE
Add @kw_only macro

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,6 +81,34 @@ const TMT1_3 = MT1_3{Int} # Julia bug https://github.com/JuliaLang/julia/issues/
 @test "Field r Default: 4\n" == Markdown.plain(REPL.fielddoc(TMT1_3, :r))
 @test "A field Default: sdaf\n" == Markdown.plain(REPL.fielddoc(TMT1_3, :c))
 
+# no positional inner constructor
+@kw_only struct KWO
+    foo
+    bar
+end
+
+function KWO(args...)
+    global outer_constructor_called = true
+    KWO(; foo="foo", bar="bar")
+end
+
+outer_constructor_called = false
+kwo = KWO(42)
+@test outer_constructor_called == true
+@test kwo.foo == "foo"
+@test kwo.bar == "bar"
+
+outer_constructor_called = false
+kwo2 = KWO(42, 43)
+@test outer_constructor_called == true
+@test kwo2.foo == "foo"
+@test kwo2.bar == "bar"
+
+outer_constructor_called = false
+kwo3 = KWO(; foo=42, bar=43)
+@test outer_constructor_called == false
+@test kwo3.foo == 42
+@test kwo3.bar == 43
 
 # parameter-less
 @with_kw_noshow mutable struct MT2


### PR DESCRIPTION
`@kw_only` behaves the same as `@with_kw` but does not declare a default constructor when no inner constructor is found.

This is useful in occasions where you might like to declare a very generic outer constructor, as in the following example.

```julia
@kw_only
struct Example
    foo
    bar
end

function Example(args...)
    # figure out values of foo and bar based on args
    Example(; foo=foo, bar=bar)
end
```

With `@with_kw`, `Example(42 "blah")` would call the default inner constructor, whereas I would like for the outer constructor to be called in this case.

I can think it may be somewhat desirable in other situations where we want the keyword constructor to be the only interface, such as when there are a lot of fields in a struct and we might like to freely add fields anywhere without changing the constructor interface.