### PR TITLE
Improve type-stability in reconstruct

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Parameters"
 uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 author = ["Mauro Werder <mauro3@runbox.com>"]
-version = "0.12.3"
+version = "0.12.4"
 
 [deps]
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -250,12 +250,14 @@ function reconstruct(::Type{T}, pp, di) where T
     else
         fieldnames(T)
     end
-    args = []
-    for (i,n) in enumerate(ns)
-        if pp isa AbstractDict
+    if pp isa AbstractDict
+        args = []
+        for n in ns
             push!(args, pop!(di, n, pp[n]))
-        else
-            push!(args, pop!(di, n, getfield(pp, n)))
+        end
+    else
+        args = map(ns) do n
+            pop!(di, n, getfield(pp, n))
         end
     end
     length(di)!=0 && error("Fields $(keys(di)) not in type $T")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -622,7 +622,7 @@ end
 @test typeof(UP4())==UP4{Int}
 @test UP4().g===9
 @test UP4().a===4.0
-
+@inferred UP4(UP4(1,2.0))
 
 # Issue 21
 # A macro to create the same fields in several types:


### PR DESCRIPTION
On master
```julia
julia> @with_kw struct A
       a::Int
       b::String
       end
A

julia> a = A(1, "a")
A
  a: Int64 1
  b: String "a"

julia> @code_warntype A(a)
MethodInstance for A(::A)
  from A(pp::A; kws...) @ Main ~/Dropbox/JuliaPackages/Parameters.jl/src/Parameters.jl:571
Arguments
  #self#::Core.Const(A)
  pp::A
Body::Any
1 ─ %1 = Main.:(var"#A#5")::Core.Const(Main.var"#A#5")
│   %2 = Core.NamedTuple()::Core.Const(NamedTuple())
│   %3 = Base.pairs(%2)::Core.Const(Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}())
│   %4 = (%1)(%3, #self#, pp)::Any
└──      return %4
```
This PR uses a tuple of fields to construct the type, so we obtain
```julia
julia> @code_warntype A(a)
MethodInstance for A(::A)
  from A(pp::A; kws...) @ Main ~/Dropbox/JuliaPackages/Parameters.jl/src/Parameters.jl:571
Arguments
  #self#::Core.Const(A)
  pp::A
Body::A
1 ─ %1 = Main.:(var"#A#5")::Core.Const(Main.var"#A#5")
│   %2 = Core.NamedTuple()::Core.Const(NamedTuple())
│   %3 = Base.pairs(%2)::Core.Const(Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}())
│   %4 = (%1)(%3, #self#, pp)::A
└──      return %4
```
The return type is inferred in this case.